### PR TITLE
Decos v1

### DIFF
--- a/assets/data/decos/decos.json
+++ b/assets/data/decos/decos.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "pot",
-    "modelPath": "models/decos/pot3.gltf",
+    "modelPath": "models/decos/pot.gltf",
     "destructible": true,
     "tags": [
       "GROUND"

--- a/assets/data/decos/decos.json
+++ b/assets/data/decos/decos.json
@@ -1,0 +1,10 @@
+[
+  {
+    "name": "pot",
+    "modelPath": "models/decos/pot3.gltf",
+    "destructible": true,
+    "tags": [
+      "GROUND"
+    ]
+  }
+]

--- a/assets/data/decos/pot.json
+++ b/assets/data/decos/pot.json
@@ -1,5 +1,0 @@
-{
-  "name": "pot",
-  "modelPath": "models/decos/pot.gltf",
-  "destructible": false
-}

--- a/assets/data/rooms/rooms.json
+++ b/assets/data/rooms/rooms.json
@@ -145,7 +145,7 @@
     "decos": [
       {
         "name": "pot",
-        "position": [0, 0, 0],
+        "position": [0, 0.05, 0],
         "chance": 1
       }
     ],

--- a/assets/data/rooms/rooms.json
+++ b/assets/data/rooms/rooms.json
@@ -74,12 +74,7 @@
     "modelPath": "models/rooms/pillars.gltf",
     "width": 1,
     "height": 2,
-    "decos": [
-      {
-        "name": "pot",
-        "position": [0, 0, 0]
-      }
-    ],
+    "decos": [],
     "doors": {
       "0": true,
       "1": true,
@@ -119,12 +114,7 @@
     "modelPath": "models/rooms/rockroom.gltf",
     "width": 1,
     "height": 1,
-    "decos": [
-      {
-        "name": "pot",
-        "position": [0, 0, 0]
-      }
-    ],
+    "decos": [],
     "doors": {
       "0": true,
       "1": true,
@@ -155,15 +145,8 @@
     "decos": [
       {
         "name": "pot",
-        "position": [0, 0, 0]
-      },
-      {
-        "name": "pot",
-        "position": [0.5, 0, 0]
-      },
-      {
-        "name": "pot",
-        "position": [0, 0.5, 0]
+        "position": [0, 0, 0],
+        "chance": 1
       }
     ],
     "doors": {

--- a/assets/data/templates/decodata.json
+++ b/assets/data/templates/decodata.json
@@ -1,0 +1,31 @@
+{
+  "type": "array",
+  "items": {
+    "type": "object",
+    "required": [
+      "name",
+      "modelPath",
+      "destructible",
+      "tags"
+    ],
+    "properties": {
+      "name": {
+        "type": "string",
+        "default": ""
+      },
+      "modelPath": {
+        "type": "string",
+        "default": ""
+      },
+      "destructible": {
+        "type": "boolean"
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/assets/data/templates/roomdata.json
+++ b/assets/data/templates/roomdata.json
@@ -46,11 +46,22 @@
         "items": {
           "type": "object",
           "required": [
-            "name",
-            "position"
+            "position",
+            "chance"
+          ],
+          "oneOf": [
+            {
+              "required": ["name"]
+            },
+            {
+              "required": ["tagString"]
+            }
           ],
           "properties": {
             "name": {
+              "type": "string"
+            },
+            "tagString": {
               "type": "string"
             },
             "position": {
@@ -59,6 +70,11 @@
                 "type": "number"
               },
               "default": [0, 0, 0]
+            },
+            "chance": {
+              "type": "number",
+              "maximum": 1,
+              "exclusiveMinimum": 0
             }
           }
         }

--- a/assets/shaders/sprite_batch_discard_alpha.frag
+++ b/assets/shaders/sprite_batch_discard_alpha.frag
@@ -1,0 +1,22 @@
+#version 150
+
+#ifdef GL_ES
+#define LOWP lowp
+precision mediump float;
+#else
+#define LOWP
+#endif
+
+in LOWP vec4 v_color;
+in vec2 v_texCoords;
+
+uniform sampler2D u_texture;
+
+out vec4 FragColor;
+
+void main() {
+    FragColor = v_color * texture(u_texture, v_texCoords);
+    if (FragColor.a == 0.0) {
+        discard;
+    }
+}

--- a/core/src/main/java/com/ducksteam/needleseye/Main.java
+++ b/core/src/main/java/com/ducksteam/needleseye/Main.java
@@ -745,6 +745,11 @@ public class Main extends Game {
 			if (room.getModelPath() == null) return;
 			assMan.load(room.getModelPath(), SceneAsset.class);
 		});
+        // Load decos
+        MapManager.decoTemplates.forEach((DecoTemplate deco) -> {
+            if (deco.getModelPath() == null) return;
+            assMan.load(deco.getModelPath(), SceneAsset.class);
+        });
 		//Walls
 		assMan.setLoader(SceneAsset.class, ".gltf", new GLTFAssetLoader());
 		assMan.load(WallObject.MODEL_ADDRESS, SceneAsset.class);

--- a/core/src/main/java/com/ducksteam/needleseye/Main.java
+++ b/core/src/main/java/com/ducksteam/needleseye/Main.java
@@ -1071,7 +1071,7 @@ public class Main extends Game {
 					if (((RoomInstance) entity).getRoom().getType() == RoomTemplate.RoomType.HALLWAY_PLACEHOLDER) return;
 				}
 				if (entity instanceof IHasHealth) ((IHasHealth) entity).update(Gdx.graphics.getDeltaTime());
-				if (entity instanceof UpgradeEntity) entity.update(Gdx.graphics.getDeltaTime());
+				if (entity instanceof UpgradeEntity || entity instanceof DecoInstance) entity.update(Gdx.graphics.getDeltaTime());
 			});
 
 			entities.forEach((Integer id, Entity entity) -> {
@@ -1193,6 +1193,8 @@ public class Main extends Game {
         /*BoundingBox bounds = new BoundingBox();
         scene.modelInstance.calculateBoundingBox(bounds);
         return camera.frustum.boundsInFrustum(bounds);*/
+
+        if (entity instanceof DecoInstance deco && deco.shattered) return true; // fixme
 
         Vector3 position = new Vector3();
         scene.modelInstance.transform.getTranslation(position);

--- a/core/src/main/java/com/ducksteam/needleseye/entity/DecoInstance.java
+++ b/core/src/main/java/com/ducksteam/needleseye/entity/DecoInstance.java
@@ -14,14 +14,12 @@ import com.badlogic.gdx.physics.bullet.collision.btCollisionObject;
 import com.badlogic.gdx.physics.bullet.collision.btCollisionShape;
 import com.badlogic.gdx.physics.bullet.dynamics.btRigidBody;
 import com.badlogic.gdx.physics.bullet.linearmath.btMotionState;
-import com.ducksteam.needleseye.Main;
 import com.ducksteam.needleseye.entity.bullet.EntityMotionState;
 import com.ducksteam.needleseye.entity.bullet.WorldTrigger;
 import com.ducksteam.needleseye.map.DecoTemplate;
 import net.mgsx.gltf.scene3d.scene.Scene;
 
 import java.util.ArrayList;
-import java.util.stream.Collectors;
 
 import static com.ducksteam.needleseye.Main.dynamicsWorld;
 
@@ -99,13 +97,13 @@ public class DecoInstance extends Entity {
             this.parent = deco;
             this.node = node;
 
-            bb = new BoundingBox();
-
             for (NodePart part : node.parts) {
-                bb.ext(part.meshPart.mesh.calculateBoundingBox());
+                part.meshPart.update();
+                if (bb != null) bb.ext(genBoundingBox(part.meshPart.center, part.meshPart.halfExtents));
+                else bb = genBoundingBox(part.meshPart.center, part.meshPart.halfExtents);
             }
 
-            shape = new btBoxShape(bb.getDimensions(new Vector3()).cpy().scl(0.5f));
+            shape = new btBoxShape(bb.getDimensions(new Vector3()).cpy().scl(0.5f).scl(0.8f, 0.6f, 0.8f));
 //            shape = Entity.obtainConvexHullShape(node.parts.get(0).meshPart.mesh, true);
 //            shape = Bullet.obtainStaticNodeShape(node, true);
 
@@ -121,6 +119,10 @@ public class DecoInstance extends Entity {
             node.globalTransform.set(new Matrix4().set(parent.transform.getRotation(new Quaternion())));
             collider.setFriction(0.8f);
             dynamicsWorld.addRigidBody(collider);
+        }
+
+        public static BoundingBox genBoundingBox(Vector3 centre, Vector3 halfExtents) {
+            return new BoundingBox(centre.cpy().sub(halfExtents), centre.cpy().add(halfExtents));
         }
 
         private void update() {
@@ -145,9 +147,6 @@ public class DecoInstance extends Entity {
     public void update(float delta) {
         if (!shattered) {
             motionState.setWorldTransform(transform);
-        } else {
-            shatterNodes.stream().sorted((n1, n2) -> (int) (n1.node.globalTransform.getTranslation(new Vector3()).sub(Main.player.getPosition()).len() - n2.node.globalTransform.getTranslation(new Vector3()).sub(Main.player.getPosition()).len())).collect(Collectors.toCollection(ArrayList::new)).getFirst().update();
-//            shatterNodes.forEach(node -> node.update(delta));
         }
     }
 

--- a/core/src/main/java/com/ducksteam/needleseye/entity/DecoInstance.java
+++ b/core/src/main/java/com/ducksteam/needleseye/entity/DecoInstance.java
@@ -1,0 +1,147 @@
+package com.ducksteam.needleseye.entity;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.graphics.g3d.model.Node;
+import com.badlogic.gdx.math.Matrix4;
+import com.badlogic.gdx.math.Quaternion;
+import com.badlogic.gdx.math.Vector3;
+import com.badlogic.gdx.physics.bullet.Bullet;
+import com.badlogic.gdx.physics.bullet.collision.Collision;
+import com.badlogic.gdx.physics.bullet.collision.btCollisionObject;
+import com.badlogic.gdx.physics.bullet.collision.btCollisionShape;
+import com.badlogic.gdx.physics.bullet.dynamics.btRigidBody;
+import com.badlogic.gdx.physics.bullet.linearmath.btMotionState;
+import com.ducksteam.needleseye.entity.bullet.EntityMotionState;
+import com.ducksteam.needleseye.entity.bullet.WorldTrigger;
+import com.ducksteam.needleseye.map.DecoTemplate;
+import net.mgsx.gltf.scene3d.scene.Scene;
+
+import java.util.ArrayList;
+
+import static com.ducksteam.needleseye.Main.dynamicsWorld;
+
+public class DecoInstance extends Entity {
+    public DecoTemplate template;
+    public RoomInstance parentRoom;
+    public boolean shattered = false;
+    private WorldTrigger shatterTrigger;
+    private final ArrayList<ShatterNode> shatterNodes = new ArrayList<>();
+
+    /**
+     * Creates a new deco
+     * @param template the template of the deco being created
+     * @param parentRoom the room the deco is placed in
+     * @param position the relative position as found in {@link com.ducksteam.needleseye.map.RoomTemplate.DecoTagPosition DecoTagPosition}
+     * @param rotation the rotation of the object
+     */
+    public DecoInstance(DecoTemplate template, RoomInstance parentRoom, Vector3 position, Quaternion rotation) {
+        super(parentRoom.getPosition().cpy().add(position), rotation, 0, template.getScene(), btCollisionObject.CollisionFlags.CF_STATIC_OBJECT | DECO_GROUP);
+
+        this.template = template;
+        this.parentRoom = parentRoom;
+
+        tryCreateWorldTrigger();
+    }
+
+    private void tryCreateWorldTrigger() {
+        if (isRenderable && template.isDestructible()) {
+            shatterTrigger = new WorldTrigger(collisionShape, transform, (Entity e) -> this.shatter(), ATTACK_GROUP, WorldTrigger.TriggerType.ONCE_ON_ENTER);
+        }
+    }
+
+    @Override
+    public void setScene(Scene scene) {
+        this.scene = scene;
+        if (isRenderable) {
+            collisionShape = Bullet.obtainStaticNodeShape(scene.modelInstance.nodes);
+            motionState = new EntityMotionState(this, transform);
+
+            Vector3 inertia = new Vector3();
+            collisionShape.calculateLocalInertia(0, inertia);
+
+            collider = new btRigidBody(0, motionState, collisionShape, inertia);
+            collider.obtain();
+            collider.setActivationState(Collision.DISABLE_DEACTIVATION);
+            collider.setUserValue(id);
+            dynamicsWorld.addRigidBody(collider);
+        }
+    }
+
+    public void shatter() {
+        Gdx.app.debug("DecoInstance", "Shattered deco " + id);
+        shatterTrigger.destroy();
+        shatterTrigger = null;
+        shattered = true;
+        dynamicsWorld.removeRigidBody(collider);
+        motionState.release();
+        collider.release();
+        for (Node node : scene.modelInstance.nodes) {
+            shatterNodes.add(new ShatterNode(node, this));
+        }
+    }
+
+    public static class ShatterNode extends btMotionState {
+        Node node;
+        btRigidBody collider;
+        btCollisionShape shape;
+        DecoInstance parent;
+
+        private static final int SHATTER_OBJECT_MASS = 0;
+
+        public ShatterNode(Node node, DecoInstance deco) {
+            this.parent = deco;
+
+            this.node = node;
+            shape = Bullet.obtainStaticNodeShape(node, true);
+
+            Vector3 inertia = new Vector3();
+            shape.calculateLocalInertia(SHATTER_OBJECT_MASS, inertia);
+
+            collider = new btRigidBody(SHATTER_OBJECT_MASS, this, shape);
+            collider.obtain();
+            collider.setActivationState(Collision.DISABLE_DEACTIVATION);
+
+            setWorldTransform(deco.transform.cpy().mul(node.globalTransform));
+            dynamicsWorld.addRigidBody(collider);
+        }
+
+        @Override
+        public void setWorldTransform(Matrix4 worldTrans) {
+            node.globalTransform.set(worldTrans);
+        }
+
+        @Override
+        public void getWorldTransform(Matrix4 worldTrans) {
+            worldTrans.set(node.globalTransform);
+        }
+    }
+
+    @Override
+    public void update(float delta) {
+        if (!shattered) {
+            motionState.setWorldTransform(transform);
+        }
+    }
+
+    @Override
+    public String getModelAddress() {
+        return template.getModelPath();
+    }
+
+    @Override
+    public synchronized void destroy() {
+        if (shattered) {
+            for (ShatterNode shatterNode : shatterNodes) {
+                shatterNode.collider.release();
+                shatterNode.collider = null;
+                shatterNode.shape.release();
+                shatterNode.shape = null;
+                shatterNode.release();
+            }
+            shatterNodes.clear();
+        } else {
+            super.destroy();
+            shatterTrigger.destroy();
+        }
+    }
+}

--- a/core/src/main/java/com/ducksteam/needleseye/entity/DecoInstance.java
+++ b/core/src/main/java/com/ducksteam/needleseye/entity/DecoInstance.java
@@ -35,15 +35,15 @@ public class DecoInstance extends Entity {
      * @param rotation the rotation of the object
      */
     public DecoInstance(DecoTemplate template, RoomInstance parentRoom, Vector3 position, Quaternion rotation) {
-        super(parentRoom.getPosition().cpy().add(position), rotation, 0, template.getScene(), btCollisionObject.CollisionFlags.CF_STATIC_OBJECT | DECO_GROUP);
+        super(parentRoom.getPosition().cpy().add(position), rotation, 0, template.getScene(), btCollisionObject.CollisionFlags.CF_STATIC_OBJECT);
 
         this.template = template;
         this.parentRoom = parentRoom;
 
-        tryCreateWorldTrigger();
+        tryCreateShatterTrigger();
     }
 
-    private void tryCreateWorldTrigger() {
+    private void tryCreateShatterTrigger() {
         if (isRenderable && template.isDestructible()) {
             shatterTrigger = new WorldTrigger(collisionShape, transform, (Entity e) -> this.shatter(), ATTACK_GROUP, WorldTrigger.TriggerType.ONCE_ON_ENTER);
         }
@@ -86,13 +86,14 @@ public class DecoInstance extends Entity {
         btCollisionShape shape;
         DecoInstance parent;
 
-        private static final int SHATTER_OBJECT_MASS = 0;
+        private static final int SHATTER_OBJECT_MASS = 100;
 
         public ShatterNode(Node node, DecoInstance deco) {
             this.parent = deco;
 
             this.node = node;
-            shape = Bullet.obtainStaticNodeShape(node, true);
+            shape = Entity.obtainConvexHullShape(node.parts.get(0).meshPart.mesh, true);
+//            shape = Bullet.obtainStaticNodeShape(node, true);
 
             Vector3 inertia = new Vector3();
             shape.calculateLocalInertia(SHATTER_OBJECT_MASS, inertia);

--- a/core/src/main/java/com/ducksteam/needleseye/entity/Entity.java
+++ b/core/src/main/java/com/ducksteam/needleseye/entity/Entity.java
@@ -52,6 +52,10 @@ public abstract class Entity implements AnimationListener {
 	public static final int PICKUP_GROUP = 1 << 15;
     /** Collision flag for triggers */
     public static final int TRIGGER_GROUP = 1 << 16;
+    /** Collision flag for decos */
+    public static final int DECO_GROUP = 1 << 17;
+    /** Collision flag for attack */
+    public static final int ATTACK_GROUP = 1 << 18;
 	//Rendering and collision data
     /**
      * Whether the entity is renderable

--- a/core/src/main/java/com/ducksteam/needleseye/entity/Entity.java
+++ b/core/src/main/java/com/ducksteam/needleseye/entity/Entity.java
@@ -1,6 +1,7 @@
 package com.ducksteam.needleseye.entity;
 
 import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.graphics.Mesh;
 import com.badlogic.gdx.graphics.g3d.ModelInstance;
 import com.badlogic.gdx.graphics.g3d.utils.AnimationController;
 import com.badlogic.gdx.graphics.g3d.utils.AnimationController.AnimationListener;
@@ -9,9 +10,7 @@ import com.badlogic.gdx.math.Quaternion;
 import com.badlogic.gdx.math.Vector3;
 import com.badlogic.gdx.math.collision.BoundingBox;
 import com.badlogic.gdx.physics.bullet.Bullet;
-import com.badlogic.gdx.physics.bullet.collision.Collision;
-import com.badlogic.gdx.physics.bullet.collision.btCollisionObject;
-import com.badlogic.gdx.physics.bullet.collision.btCollisionShape;
+import com.badlogic.gdx.physics.bullet.collision.*;
 import com.badlogic.gdx.physics.bullet.dynamics.btRigidBody;
 import com.ducksteam.needleseye.Main;
 import com.ducksteam.needleseye.entity.bullet.EntityMotionState;
@@ -227,6 +226,26 @@ public abstract class Entity implements AnimationListener {
 		motionState.getWorldTransform(modelInstance.transform);
 		return modelInstance;
 	}
+
+    /**
+     * Create a convex hull shape (ideal for dynamic entities)
+     * @param mesh the mesh to create the shape of
+     * @param optimize whether to optimize the collision shape to more closely fit the object
+     * @return the new collision shape
+     */
+    public static btConvexHullShape obtainConvexHullShape(final Mesh mesh, boolean optimize) {
+        final btConvexHullShape shape = new btConvexHullShape(mesh.getVerticesBuffer(false), mesh.getNumVertices(),
+            mesh.getVertexSize());
+        if (!optimize) return shape;
+        // now optimize the shape
+        final btShapeHull hull = new btShapeHull(shape);
+        hull.buildHull(shape.getMargin());
+        final btConvexHullShape result = new btConvexHullShape(hull);
+        // delete the temporary shape
+        shape.dispose();
+        hull.dispose();
+        return result;
+    }
 
 	/**
 	 * Returns the scene asset of the entity

--- a/core/src/main/java/com/ducksteam/needleseye/entity/Entity.java
+++ b/core/src/main/java/com/ducksteam/needleseye/entity/Entity.java
@@ -87,7 +87,7 @@ public abstract class Entity implements AnimationListener {
     /**
      * The scene asset of the entity
      */
-	private Scene scene;
+	protected Scene scene;
 
     /** The centre of the bounding sphere*/
     private final Vector3 boundingSphereCentre = new Vector3();

--- a/core/src/main/java/com/ducksteam/needleseye/entity/Entity.java
+++ b/core/src/main/java/com/ducksteam/needleseye/entity/Entity.java
@@ -131,7 +131,7 @@ public abstract class Entity implements AnimationListener {
 	 */
 
 	public Entity(Vector3 position, Quaternion rotation, Scene scene) {
-		this(position, rotation, 0f, scene, btCollisionObject.CollisionFlags.CF_STATIC_OBJECT | GROUND_GROUP);
+		this(position, rotation, 0f, scene, btCollisionObject.CollisionFlags.CF_STATIC_OBJECT);
 	}
 
 	/**
@@ -206,7 +206,6 @@ public abstract class Entity implements AnimationListener {
 			// Creates rigid body
 			collider = new btRigidBody(mass, motionState, collisionShape, inertia);
 			collider.obtain();
-			collider.setCollisionFlags(collider.getCollisionFlags() | flags);
 			collider.setActivationState(Collision.DISABLE_DEACTIVATION); // disable entity deactivation
 			collider.setUserValue(this.id); // set user value to entity id
 			if (this instanceof RoomInstance) collider.setFriction(0.2f); // increase friction on room instances
@@ -260,7 +259,6 @@ public abstract class Entity implements AnimationListener {
 			// Creates rigid body
 			collider = new btRigidBody(mass, motionState, collisionShape, inertia);
 			collider.obtain();
-			collider.setCollisionFlags(collider.getCollisionFlags() | flags);
 			collider.setActivationState(Collision.DISABLE_DEACTIVATION); // disable entity deactivation
 			collider.setUserValue(this.id); // set user value to entity id
 			if (this instanceof RoomInstance) collider.setFriction(0.2f); // increase friction on room instances
@@ -365,7 +363,7 @@ public abstract class Entity implements AnimationListener {
 	/**
 	 * Disposes all relevant data from the entity
 	 * */
-	public void destroy() {
+	public synchronized void destroy() {
 		dynamicsWorld.removeRigidBody(collider);
         collisionShape.dispose();
         motionState.dispose();

--- a/core/src/main/java/com/ducksteam/needleseye/entity/HallwayPlaceholderRoom.java
+++ b/core/src/main/java/com/ducksteam/needleseye/entity/HallwayPlaceholderRoom.java
@@ -25,7 +25,7 @@ public class HallwayPlaceholderRoom extends RoomInstance {
      * The template for a hallway placeholder room.
      * Very generic
      */
-    public static final RoomTemplate HALLWAY_PLACEHOLDER_TEMPLATE = new RoomTemplate(RoomTemplate.RoomType.HALLWAY_PLACEHOLDER, 0, 0, false, null, new Vector3(0, 0, 0), new ArrayList<>());
+    public static final RoomTemplate HALLWAY_PLACEHOLDER_TEMPLATE = new RoomTemplate(RoomTemplate.RoomType.HALLWAY_PLACEHOLDER, 0, 0, false, null, new Vector3(0, 0, 0), new ArrayList<>(), new ArrayList<>());
 
     /**
      * Create a new hallway placeholder room

--- a/core/src/main/java/com/ducksteam/needleseye/entity/enemies/OrbulonEnemy.java
+++ b/core/src/main/java/com/ducksteam/needleseye/entity/enemies/OrbulonEnemy.java
@@ -64,7 +64,6 @@ public class OrbulonEnemy extends EnemyEntity {
 		// create rigid body
 		collider = new btRigidBody(MASS, motionState, collisionShape, inertia);
 		collider.obtain();
-		collider.setCollisionFlags(collider.getCollisionFlags());
 		collider.setActivationState(Collision.DISABLE_DEACTIVATION); // entity should not be deactivated
 		collider.setUserValue(this.id); // set entity id
 		collider.setAngularFactor(Vector3.Y); // lock x/z rotation

--- a/core/src/main/java/com/ducksteam/needleseye/entity/enemies/WormEnemy.java
+++ b/core/src/main/java/com/ducksteam/needleseye/entity/enemies/WormEnemy.java
@@ -66,7 +66,6 @@ public class WormEnemy extends EnemyEntity{
         // create rigid body
         collider = new btRigidBody(MASS, motionState, collisionShape, inertia);
         collider.obtain();
-        collider.setCollisionFlags(collider.getCollisionFlags());
         collider.setActivationState(Collision.DISABLE_DEACTIVATION); // entity should not be deactivated
         collider.setUserValue(this.id); // set entity id
         collider.setAngularFactor(Vector3.Y); // lock x/z rotation

--- a/core/src/main/java/com/ducksteam/needleseye/map/DecoTag.java
+++ b/core/src/main/java/com/ducksteam/needleseye/map/DecoTag.java
@@ -1,0 +1,90 @@
+package com.ducksteam.needleseye.map;
+
+import com.badlogic.gdx.Gdx;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+
+/**
+ * All possible tags for decos
+ * @author SkySourced
+ */
+public enum DecoTag {
+    ALL((DecoTag) null), // all tags should have a parent trail to this
+    // placement
+    GROUND(ALL),
+    CEILING(ALL),
+    WALL(ALL),
+    // properties
+    LIGHT(ALL);
+
+    final ArrayList<DecoTag> parents;
+    final ArrayList<DecoTag> children;
+
+    DecoTag(DecoTag... parent) {
+        this.parents = new ArrayList<>();
+        if(parent[0] != null) parents.addAll(List.of(parent));
+
+        this.children = new ArrayList<>();
+        for (DecoTag parentTag : parents) {
+            parentTag.children.add(this);
+        }
+    }
+
+    /**
+     * Check if this tag is a child of the given parent
+     * @param target the parent tag
+     * @return true if this tag is a child of the parent, or if the tags are the same
+     */
+    public boolean isChildOf(DecoTag target) {
+        if (this == target || target == ALL || this.parents.contains(target)) return true;
+
+        HashSet<DecoTag> visited = new HashSet<>(); // targets compared already
+        HashSet<DecoTag> seen = new HashSet<>(this.parents); // targets to compare
+        while (true) {
+            if (seen.isEmpty()) return false;
+            if (seen.contains(target)) return true;
+            for (DecoTag tag : seen) {
+                visited.add(tag);
+                for (DecoTag parent : tag.parents) {
+                    if (parent == target) return true;
+                    if (!visited.contains(parent)) seen.add(parent);
+                }
+                seen.remove(tag);
+            }
+        }
+    }
+
+    /**
+     * Quick inversion of <code>isChildOf</code>
+     * @param child the child tag
+     * @return true if this tag is a parent of the child, or if the tags are the same
+     */
+    public boolean isParentOf(DecoTag child) {
+        return child.isChildOf(this);
+    }
+
+    /**
+     * Get the tag from the name
+     * @param name the name of the tag
+     * @return the tag
+     */
+    public static DecoTag fromString(String name) {
+        try {
+            return DecoTag.valueOf(name.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            Gdx.app.error("DecoTag", "Invalid tag name: " + name);
+            return null;
+        }
+    }
+
+    /**
+     * Get the name of the tag in lowercase
+     * @return the name of the tag
+     */
+    @Override
+    public String toString() {
+        return super.toString().toLowerCase();
+    }
+}

--- a/core/src/main/java/com/ducksteam/needleseye/map/DecoTemplate.java
+++ b/core/src/main/java/com/ducksteam/needleseye/map/DecoTemplate.java
@@ -1,0 +1,68 @@
+package com.ducksteam.needleseye.map;
+
+import com.badlogic.gdx.utils.Array;
+import com.badlogic.gdx.utils.JsonValue;
+import com.ducksteam.needleseye.Main;
+import net.mgsx.gltf.scene3d.scene.Scene;
+import net.mgsx.gltf.scene3d.scene.SceneAsset;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+
+public class DecoTemplate {
+    private String modelPath;
+    private String name;
+    private boolean destructible;
+    public HashSet<DecoTag> tags;
+
+    /**
+     * Creates an empty deco template to be filled with setters
+     */
+    public DecoTemplate() {}
+
+    /**
+     * Loads deco templates from JSON
+     * @param map the JSON array to read from
+     * @return the parsed templates
+     */
+    public static ArrayList<DecoTemplate> loadDecoTemplates(Array<JsonValue> map){
+        ArrayList<DecoTemplate> dtArray = new ArrayList<>();
+
+        for (JsonValue v : map){
+            DecoTemplate dt = new DecoTemplate();
+            dt.modelPath = v.get("modelPath").asString();
+            dt.name = v.get("name").asString();
+            dt.destructible = v.get("destructible").asBoolean();
+            HashSet<DecoTag> tags = new HashSet<>();
+            for (JsonValue t : v.get("tags")){
+                tags.add(DecoTag.valueOf(t.asString()));
+            }
+            dt.tags = tags;
+
+            dtArray.add(dt);
+        }
+
+        return dtArray;
+    }
+
+    public String getModelPath() {
+        return modelPath;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public boolean isDestructible() {
+        return destructible;
+    }
+
+    /**
+     * Get the scene of the deco
+     * @return a new copy of the scene
+     */
+    public Scene getScene() {
+        if (getModelPath() != null) return new Scene(((SceneAsset) Main.assMan.get(getModelPath())).scene);
+        else return null;
+    }
+}

--- a/core/src/main/java/com/ducksteam/needleseye/map/MapManager.java
+++ b/core/src/main/java/com/ducksteam/needleseye/map/MapManager.java
@@ -30,6 +30,8 @@ public class MapManager {
      * All room templates
      */
     public static ArrayList<RoomTemplate> roomTemplates;
+    /** All deco templates */
+    public static ArrayList<DecoTemplate> decoTemplates;
     /**
      * The levels from the current run
      */
@@ -112,19 +114,29 @@ public class MapManager {
      */
     public MapManager(boolean visualise) {
         roomTemplates = new ArrayList<>();
+        decoTemplates = new ArrayList<>();
         levels = new ArrayList<>();
         levelIndex = 1;
 
         Json json = new Json();
         Array<JsonValue> map;
+
+        try {
+            map = json.fromJson(null, Gdx.files.internal("data/decos/decos.json"));
+            decoTemplates.addAll(DecoTemplate.loadDecoTemplates(map));
+        } catch (Exception e) {
+            Gdx.app.error("DecoTemplate", "Error loading deco templates", e);
+        }
+        Gdx.app.debug("MapManager", "Loaded data for " + decoTemplates.size() + " deco templates");
+
         try {
             map = json.fromJson(null, Gdx.files.internal("data/rooms/rooms.json"));
             roomTemplates.addAll(RoomTemplate.loadRoomTemplates(map));
         } catch (Exception e) {
             Gdx.app.error("RoomTemplate", "Error loading room templates", e);
         }
-
         Gdx.app.debug("MapManager", "Loaded data for " + roomTemplates.size() + " room templates");
+
         if (visualise) {
             Gdx.app.log("MapManager", "Visualising map generation");
             visualiser = new MapGenerationVisualiser();

--- a/core/src/main/java/com/ducksteam/needleseye/map/MapManager.java
+++ b/core/src/main/java/com/ducksteam/needleseye/map/MapManager.java
@@ -616,6 +616,14 @@ public class MapManager {
         return roomTemplates.stream().filter(room -> room.getName().equals(name)).findFirst().orElse(null);
     }
 
+    /** Get a deco template with a specific name
+     * @param name the name of the deco
+     * @return the deco template or null if not found
+     */
+    public static DecoTemplate getDecoWithName(String name){
+        return decoTemplates.stream().filter(deco -> deco.getName().equals(name)).findFirst().orElse(null);
+    }
+
     /**
      * Get the room space position of a world space position
      * @param pos the world space position

--- a/core/src/main/java/com/ducksteam/needleseye/player/Player.java
+++ b/core/src/main/java/com/ducksteam/needleseye/player/Player.java
@@ -11,6 +11,7 @@ import com.badlogic.gdx.physics.bullet.dynamics.btDiscreteDynamicsWorld;
 import com.badlogic.gdx.physics.bullet.dynamics.btRigidBody;
 import com.ducksteam.needleseye.Config;
 import com.ducksteam.needleseye.Main;
+import com.ducksteam.needleseye.entity.DecoInstance;
 import com.ducksteam.needleseye.entity.Entity;
 import com.ducksteam.needleseye.entity.IHasHealth;
 import com.ducksteam.needleseye.entity.bullet.EntityMotionState;

--- a/core/src/main/java/com/ducksteam/needleseye/player/Player.java
+++ b/core/src/main/java/com/ducksteam/needleseye/player/Player.java
@@ -302,6 +302,10 @@ public class Player extends Entity implements IHasHealth {
                     enemyLogic.run(enemy);
                 }
             }
+            if (entity instanceof DecoInstance deco && deco.template.isDestructible() && !deco.shattered) {
+                tempVec = deco.getPosition().sub(player.getPosition());
+                if (tempVec.len() < ATTACK_RANGE) deco.shatter();
+            }
         }
     }
 

--- a/core/src/main/java/com/ducksteam/needleseye/stages/MainStage.java
+++ b/core/src/main/java/com/ducksteam/needleseye/stages/MainStage.java
@@ -87,12 +87,8 @@ public class MainStage extends StageTemplate {
 		playButton.addListener(new InputListener(){
 			@Override
 			public boolean touchDown (InputEvent event, float x, float y, int pointer, int button) {
-				if (Main.getActiveUIAnim() == null){
-					Main.setActiveUIAnim(Main.transitionAnimation, MainStage.this::update, () -> {
-                        Main.setCurrentSave(new Playthrough("seed", "name"));
-                        setGameState(Main.GameState.THREAD_SELECT);
-                    });
-				}
+                Main.setCurrentSave(new Playthrough("seed", "name"));
+                setGameState(Main.GameState.THREAD_TRANSITION);
 				return true;
 			}
 		});

--- a/lwjgl3/src/main/java/com/ducksteam/needleseye/lwjgl3/Lwjgl3Launcher.java
+++ b/lwjgl3/src/main/java/com/ducksteam/needleseye/lwjgl3/Lwjgl3Launcher.java
@@ -56,7 +56,7 @@ public class Lwjgl3Launcher {
 
         configuration.setHdpiMode(HdpiMode.Pixels); // use actual pixels for resolution
 
-        configuration.setBackBufferConfig(8, 8, 8, 8, 16, 0, 4);
+        configuration.setBackBufferConfig(8, 8, 8, 8, 16, 8, 4);
 
         configuration.setWindowIcon("icon_128.png", "icon_64.png", "icon_32.png", "icon_16.png"); // application icon
 


### PR DESCRIPTION
Decos & deco shattering are in a place that I'm happy with for now, but there are definitely some improvements to be made.
Specifically:
- Collision shapes are a heavy approximation
- The original model (at least for the pot) has the shatter lines visible. I don't know whether this is useful for readability or not but having models swap out pre-shattering might be good
- Better shatter physics. The current force is from the colliders generating on top of each other and flying apart, which looks alright but is not physically based. Ideally this would be based on the 3d whip animation but that's a big task
- Improved positioning based on surface normal. This would be for wall decorations like vines, but could simplify how decos are placed in general. This one definitely isn't as important